### PR TITLE
index creation idempotent + fixed issue in `sk` generation in query

### DIFF
--- a/serverless/dynamoplus/dynamo_plus.py
+++ b/serverless/dynamoplus/dynamo_plus.py
@@ -215,12 +215,13 @@ def query(collection_name: str, query: dict = None, start_from: str = None,
             raise HandlerException(HandlerExceptionErrorCodes.BAD_REQUEST,
                                    "{} is not a valid collection".format(collection_name))
         domain_service = DomainService(collection_metadata)
-
+        ## TODO - missing order unique in the query
         query_id = "__".join(predicate.get_fields())
-        index_metadata = SystemService.get_index(query_id, collection_name)
-        if index_metadata is None:
+        index_matching_conditions = SystemService.get_index_matching_fields(predicate.get_fields(),collection_name,None)
+        if index_matching_conditions is None:
             raise HandlerException(HandlerExceptionErrorCodes.BAD_REQUEST, "no index {} found".format(query_id))
-        documents, last_evaluated_key = domain_service.query(predicate, limit, start_from)
+        ## Since the sk should be built using the index it is necessary to pass the index matching the conditions
+        documents, last_evaluated_key = domain_service.query(predicate,index_matching_conditions.conditions, limit, start_from)
     return documents, last_evaluated_key
 
 

--- a/serverless/dynamoplus/models/system/index/index.py
+++ b/serverless/dynamoplus/models/system/index/index.py
@@ -6,7 +6,7 @@ from dynamoplus.utils.utils import auto_str
 
 @auto_str
 class Index(object):
-    def __init__(self, uid:str, collection_name: str, conditions: List[str], ordering_key: str = None, index_name:str = None):
+    def __init__(self, uid:str, collection_name: str, conditions: List[str], ordering_key: str = None):
         self._collection_name = collection_name
         self._conditions = conditions
         conditions_set = set(self._conditions)
@@ -15,7 +15,7 @@ class Index(object):
         if condition_set_length != len(self._conditions) and condition_set_length == 1:
             self._range_condition = conditions_set.pop()
         self._ordering_key = ordering_key
-        self._index_name = index_name if index_name else Index.index_name_generator(self._conditions,self._ordering_key)
+        self._index_name = Index.index_name_generator(self._conditions,self._ordering_key)
         self._uid = uid
 
     @property

--- a/serverless/dynamoplus/repository/models.py
+++ b/serverless/dynamoplus/repository/models.py
@@ -103,11 +103,11 @@ class Model(object):
 
 
 class QueryModel(Model):
-    def __init__(self, collection: Collection, predicate: Predicate):
+    def __init__(self, collection: Collection, index_fields:List[str], predicate: Predicate):
         self.predicate = predicate
         super().__init__(collection, None)
         self.collection = collection
-        self.fields = self.predicate.get_fields()
+        self.fields = index_fields
         self.values = self.predicate.get_values()
 
     def pk(self):
@@ -193,14 +193,15 @@ class IndexModel(Model):
 @auto_str
 class Query(object):
 
-    def __init__(self, predicate: Predicate, collection: Collection, limit: int = None, start_from: Model = None):
+    def __init__(self, predicate: Predicate, collection: Collection, index_fields:List[str], limit: int = None, start_from: Model = None):
         self.start_from = start_from
         self.predicate = predicate
         self.collection = collection
+        self.index_fields = index_fields
         self.limit = limit
 
     def get_model(self) -> QueryModel:
-        return QueryModel(self.collection, self.predicate)
+        return QueryModel(self.collection, self.index_fields, self.predicate)
 
     def __eq__(self, o: object) -> bool:
         if isinstance(o, Query):

--- a/serverless/dynamoplus/repository/models.py
+++ b/serverless/dynamoplus/repository/models.py
@@ -114,7 +114,7 @@ class QueryModel(Model):
         return None
 
     def sk(self):
-        return self.collection.name+("#{}".format("#".join(self.fields)) if len(self.fields)>0 else "")
+        return self.collection.name+("#{}".format("#".join(self.fields)) if self.fields is not None and  len(self.fields)>0 else "")
 
     def data(self):
         if self.predicate.is_range():

--- a/serverless/dynamoplus/service/domain/domain.py
+++ b/serverless/dynamoplus/service/domain/domain.py
@@ -1,11 +1,13 @@
 from typing import *
 
 from dynamoplus.models.query.conditions import Predicate, AnyMatch
+from dynamoplus.models.system.index.index import Index
 from dynamoplus.repository.models import Query as QueryRepository
 from dynamoplus.repository.repositories import DynamoPlusRepository, IndexDynamoPlusRepository
 
 from dynamoplus.models.system.collection.collection import Collection, AttributeDefinition, AttributeType
 from dynamoplus.service.indexing_decorator import create_document, update_document, delete_document
+
 
 class DomainService:
     def __init__(self, collection: Collection):
@@ -35,13 +37,13 @@ class DomainService:
     def find_all(self, limit: int = None, start_from: str = None):
         return self.query(AnyMatch(), limit, start_from)
 
-    def query(self, predicate: Predicate, limit: int = None, start_from: str = None):
+    def query(self, predicate: Predicate, index: Index, limit: int = None, start_from: str = None):
         repository = DynamoPlusRepository(self.collection)
         last_evaluated_item = None
         if start_from:
             ## from predicate to index => Index(self.collection, [conditions from predicate])
             last_evaluated_item = repository.get(start_from)
-        query: QueryRepository = QueryRepository(predicate, self.collection, limit, last_evaluated_item)
+        query: QueryRepository = QueryRepository(predicate, self.collection,index, limit, last_evaluated_item)
         result = repository.query_v2(query)
 
         return list(map(lambda dm: dm.document, result.data)), result.lastEvaluatedKey

--- a/serverless/dynamoplus/service/system/system.py
+++ b/serverless/dynamoplus/service/system/system.py
@@ -284,7 +284,7 @@ class SystemService:
         if start_from:
             last_evaluated_key = repository.get(start_from)
         query: QueryRepository = QueryRepository(Eq("collection.name", collection_name),
-                                                 index_metadata, limit, last_evaluated_key)
+                                                 index_metadata, ["collection.name"], limit, last_evaluated_key)
         result = repository.query_v2(query)
         return list(map(lambda m: from_dict_to_index(m.document), result.data)), result.lastEvaluatedKey
 

--- a/serverless/dynamoplus/service/validation_service.py
+++ b/serverless/dynamoplus/service/validation_service.py
@@ -44,7 +44,6 @@ COLLECTION_SCHEMA_DEFINITION = {
 INDEX_SCHEMA_DEFINITION = {
     "properties": {
         "uid": {"type": "string", "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"},
-        "name": {"type": "string"},
         "collection": COLLECTION_SCHEMA_DEFINITION,
         "conditions": {"type": "array", "items": {"type": "string"}}
     },

--- a/serverless/test/aws/http/handler/test_handler.py
+++ b/serverless/test/aws/http/handler/test_handler.py
@@ -70,7 +70,7 @@ class TestHttpHandler(unittest.TestCase):
         ##index 2 - even
         self.systemTable.put_item(Item={"pk": "index#2", "sk": "index", "data": "2",
                                         "document": "{\"uid\": \"2\",\"name\":\"even\",\"collection\":{\"id_key\":\"id\",\"name\":\"example\"},\"conditions\": [\"even\"]}"})
-        self.systemTable.put_item(Item={"pk": "index#2", "sk": "index#collection.name", "data": "example",
+        self.systemTable.put_item(Item={"pk": "index#2", "sk": "index#name", "data": "example",
                                         "document": "{\"uid\": \"2\",\"name\":\"even\",\"collection\":{\"id_key\":\"id\",\"name\":\"example\"},\"conditions\": [\"even\"]}"})
         self.systemTable.put_item(Item={"pk": "index#2", "sk": "index#collection.name#name", "data": "example#even",
                                         "document": "{\"uid\": \"2\",\"name\":\"even\",\"collection\":{\"id_key\":\"id\",\"name\":\"example\"},\"conditions\": [\"even\"]}"})

--- a/serverless/test/dynamoplus/repository/test_models.py
+++ b/serverless/test/dynamoplus/repository/test_models.py
@@ -67,7 +67,7 @@ class TestModels(unittest.TestCase):
 
     def test_query_model_range(self):
         collection = Collection("example", "id", "ordering")
-        query_model = QueryModel(collection,Range("field1","value1","value2"))
+        query_model = QueryModel(collection,["field1"], Range("field1","value1","value2"))
         self.assertIsNone(query_model.pk())
         self.assertEqual("example#field1", query_model.sk())
         self.assertEqual(2, len(query_model.data()))
@@ -76,7 +76,7 @@ class TestModels(unittest.TestCase):
 
     def test_query_model_any_match(self):
         collection = Collection("example", "id", "ordering")
-        query_model = QueryModel(collection,AnyMatch())
+        query_model = QueryModel(collection, [], AnyMatch())
         self.assertIsNone(query_model.pk())
         self.assertEqual("example", query_model.sk())
         self.assertIsNone(query_model.data())

--- a/serverless/test/dynamoplus/repository/test_repository.py
+++ b/serverless/test/dynamoplus/repository/test_repository.py
@@ -177,7 +177,7 @@ class TestDynamoPlusRepository(unittest.TestCase):
             self.table.put_item(Item={"pk": "example#" + str(i), "sk": "example#attribute1", "data": str(i % 2),
                                       "document": json.dumps(document)})
 
-        query_model = Query(Eq("attribute1", "1"), self.collection)
+        query_model = Query(Eq("attribute1", "1"), self.collection, ["attribute1"])
         result = repository.query_v2(query_model)
         self.assertIsNotNone(result)
         self.assertEqual(len(result.data), 5)
@@ -194,7 +194,7 @@ class TestDynamoPlusRepository(unittest.TestCase):
                                       "data": str(i % 2) + "#value_" + str(i),
                                       "document": json.dumps(document)})
 
-        query_model = Query(And([Eq("attribute1", "1"), Eq("attribute2", "value_3")]), self.collection)
+        query_model = Query(And([Eq("attribute1", "1"), Eq("attribute2", "value_3")]), self.collection,["attribute1","attribute2"])
         result = repository.query_v2(query_model)
         self.assertIsNotNone(result)
         self.assertEqual(len(result.data), 1)
@@ -211,7 +211,7 @@ class TestDynamoPlusRepository(unittest.TestCase):
                                       "data": str(i % 2) + "#" + str(i),
                                       "document": json.dumps(document)})
 
-        query_model = Query(And([Eq("attribute1", "1"), Range("attribute3", "3", "7")]), self.collection)
+        query_model = Query(And([Eq("attribute1", "1"), Range("attribute3", "3", "7")]), self.collection,["attribute1","attribute3"])
         result = repository.query_v2(query_model)
         self.assertIsNotNone(result)
         self.assertEqual(len(result.data), 3)
@@ -238,8 +238,11 @@ class TestDynamoPlusRepository(unittest.TestCase):
                                       "data": str(i % 2) + "#" + f"{i:08}",
                                       "document": json.dumps(document)})
 
-        query_model = Query(And([Eq("attribute1", "1"), Range("attribute3", "00000020", "00000030")]), self.collection,
-                            3)
+        query_model = Query(
+            And([Eq("attribute1", "1"), Range("attribute3", "00000020", "00000030")]),
+            self.collection,
+            ["attribute1","attribute3"],
+            3)
         result = repository.query_v2(query_model)
         self.assertIsNotNone(result)
         self.assertEqual(len(result.data), 3)
@@ -274,6 +277,7 @@ class TestDynamoPlusRepository(unittest.TestCase):
         query_model = Query(
             And([Eq("attribute1", "1"), Range("attribute3", "00000020", "00000040")]),
             self.collection,
+            ["attribute1","attribute3"],
             3,
             starting_after)
         result = repository.query_v2(query_model)
@@ -288,6 +292,9 @@ class TestDynamoPlusRepository(unittest.TestCase):
         self.assertEqual("1", result.data[2].document["attribute1"])
         self.assertEqual("value_00000033", result.data[2].document["attribute2"])
         self.assertEqual("00000033", result.data[2].document["attribute3"])
+
+    def test_query_v2_subset_of_conditions_matching_index(self):
+        raise Exception("whatever")
     #
     # def test_query_all(self):
     #     for i in range(1, 10):

--- a/serverless/test/dynamoplus/repository/test_repository.py
+++ b/serverless/test/dynamoplus/repository/test_repository.py
@@ -194,7 +194,8 @@ class TestDynamoPlusRepository(unittest.TestCase):
                                       "data": str(i % 2) + "#value_" + str(i),
                                       "document": json.dumps(document)})
 
-        query_model = Query(And([Eq("attribute1", "1"), Eq("attribute2", "value_3")]), self.collection,["attribute1","attribute2"])
+        query_model = Query(And([Eq("attribute1", "1"), Eq("attribute2", "value_3")]), self.collection,
+                            ["attribute1", "attribute2"])
         result = repository.query_v2(query_model)
         self.assertIsNotNone(result)
         self.assertEqual(len(result.data), 1)
@@ -211,7 +212,8 @@ class TestDynamoPlusRepository(unittest.TestCase):
                                       "data": str(i % 2) + "#" + str(i),
                                       "document": json.dumps(document)})
 
-        query_model = Query(And([Eq("attribute1", "1"), Range("attribute3", "3", "7")]), self.collection,["attribute1","attribute3"])
+        query_model = Query(And([Eq("attribute1", "1"), Range("attribute3", "3", "7")]), self.collection,
+                            ["attribute1", "attribute3"])
         result = repository.query_v2(query_model)
         self.assertIsNotNone(result)
         self.assertEqual(len(result.data), 3)
@@ -241,7 +243,7 @@ class TestDynamoPlusRepository(unittest.TestCase):
         query_model = Query(
             And([Eq("attribute1", "1"), Range("attribute3", "00000020", "00000030")]),
             self.collection,
-            ["attribute1","attribute3"],
+            ["attribute1", "attribute3"],
             3)
         result = repository.query_v2(query_model)
         self.assertIsNotNone(result)
@@ -277,7 +279,7 @@ class TestDynamoPlusRepository(unittest.TestCase):
         query_model = Query(
             And([Eq("attribute1", "1"), Range("attribute3", "00000020", "00000040")]),
             self.collection,
-            ["attribute1","attribute3"],
+            ["attribute1", "attribute3"],
             3,
             starting_after)
         result = repository.query_v2(query_model)
@@ -293,8 +295,24 @@ class TestDynamoPlusRepository(unittest.TestCase):
         self.assertEqual("value_00000033", result.data[2].document["attribute2"])
         self.assertEqual("00000033", result.data[2].document["attribute3"])
 
-    # def test_query_v2_subset_of_conditions_matching_index(self):
-    #     raise Exception("whatever")
+    def test_query_v2_subset_of_conditions_matching_index(self):
+        repository = DynamoPlusRepository(self.collection)
+        for i in range(1, 10):
+            document = {"id": str(i), "attribute1": str(i % 2), "attribute2": "value_" + str(i)}
+            self.table.put_item(
+                Item={"pk": "example#" + str(i), "sk": "example", "data": str(i), "document": json.dumps(document)})
+            self.table.put_item(Item={"pk": "example#" + str(i), "sk": "example#attribute1#attribute2",
+                                      "data": str(i % 2) + "#value_" + str(i),
+                                      "document": json.dumps(document)})
+
+        query_model = Query(And([Eq("attribute1", "1")]), self.collection,
+                            ["attribute1", "attribute2"])
+        result = repository.query_v2(query_model)
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result.data), 5)
+        for idx, r in enumerate(result.data):
+            self.assertEqual("1", r.document["attribute1"])
+            self.assertEqual(1, int(r.document["attribute2"].replace("value_",""))%2)
     #
     # def test_query_all(self):
     #     for i in range(1, 10):

--- a/serverless/test/dynamoplus/repository/test_repository.py
+++ b/serverless/test/dynamoplus/repository/test_repository.py
@@ -293,8 +293,8 @@ class TestDynamoPlusRepository(unittest.TestCase):
         self.assertEqual("value_00000033", result.data[2].document["attribute2"])
         self.assertEqual("00000033", result.data[2].document["attribute3"])
 
-    def test_query_v2_subset_of_conditions_matching_index(self):
-        raise Exception("whatever")
+    # def test_query_v2_subset_of_conditions_matching_index(self):
+    #     raise Exception("whatever")
     #
     # def test_query_all(self):
     #     for i in range(1, 10):

--- a/serverless/test/dynamoplus/service/domain/test_domainService.py
+++ b/serverless/test/dynamoplus/service/domain/test_domainService.py
@@ -76,7 +76,7 @@ class TestDomainService(unittest.TestCase):
             Model(self.exampleCollectionMetadata, {"id": "1", "attribute1": "1"}),
             Model(self.exampleCollectionMetadata, {"id": "2", "attribute1": "1"})
         ])
-        expected_query = Query(AnyMatch(),self.exampleCollectionMetadata)
+        expected_query = Query(AnyMatch(),self.exampleCollectionMetadata,[])
         # when
         documents, last_evaluated_key = self.domainService.find_all()
         # then

--- a/serverless/test/dynamoplus/service/system/test_systemService.py
+++ b/serverless/test/dynamoplus/service/system/test_systemService.py
@@ -257,7 +257,7 @@ class TestSystemService(unittest.TestCase):
     @patch.object(DynamoPlusRepository, "query_v2")
     @patch.object(DynamoPlusRepository, "__init__")
     def test_queryIndex_by_CollectionByName_generator(self, mock_index_dynamoplus_repository, mock_find):
-        expected_query = Query(Eq("collection.name", "example"), Collection("index", "uid"), 2)
+        expected_query = Query(Eq("collection.name", "example"), Collection("index", "uid"),["collection.name"], 2)
         mock_index_dynamoplus_repository.return_value = None
         mock_find.side_effect = [
             self.fake_query_result("1", "2"),

--- a/serverless/test/dynamoplus/test_dynamo_plus.py
+++ b/serverless/test/dynamoplus/test_dynamo_plus.py
@@ -75,5 +75,5 @@ class TestDynamoPlusHandler(unittest.TestCase):
         self.assertEqual(len(documents), len(expected_documents))
         self.assertTrue(mock_get_collection_by_name.called_with("example"))
         self.assertTrue(mock_get_index.called_with("attribute1"))
-        self.assertEqual(call(expected_predicate, None, None), mock_find_by_index.call_args_list[0])
+        self.assertEqual(call(expected_predicate,["attribute1"], None, None), mock_find_by_index.call_args_list[0])
         #self.assertEqual(call(expected_index,expected_document_example,None,None),mock_find_by_index.call_args_list[0])


### PR DESCRIPTION
when creating an index with the same name it returns the index already created 

in the query the sk is built from index conditions and not from query conditions